### PR TITLE
Add support for Red Hat based images

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,4 +17,7 @@ hetzner_installimage_install_partitions:
 hetzner_installimage_install_image: /root/.oldroot/nfs/images/Ubuntu-1604-xenial-64-minimal.tar.gz
 # prevent reinstallation of running servers with /etc/hostcode file
 hetzner_installimage_ignore_hostcode: False
+
+# know hosts file location on ansible control node
+hetzner_installimage_known_hosts_file: "{{ lookup('env','HOME') + '/.ssh/known_hosts' }}"
 ...

--- a/tasks/add_server_to_known_hosts.yml
+++ b/tasks/add_server_to_known_hosts.yml
@@ -1,0 +1,14 @@
+---
+- name: scan for server's public key
+  shell: "ssh-keyscan -t ecdsa {{ inventory_hostname }}"
+  register: ssh_known_host_results
+  ignore_errors: yes
+  delegate_to: localhost
+
+- name: ensure the server's public key in known_hosts exists
+  known_hosts:
+    name: "{{ inventory_hostname }}"
+    key: "{{ ssh_known_host_results.stdout }}"
+    path: "{{ hetzner_installimage_known_hosts_file }}"
+  delegate_to: localhost
+...

--- a/tasks/installimage.yml
+++ b/tasks/installimage.yml
@@ -47,6 +47,8 @@
     timeout: 180
   delegate_to: localhost
 
+- include: add_server_to_known_hosts.yml
+
 # uses raw instead of module as python might ont be installed yet
 - name: easy os detector
   raw: 'echo -n $(test -f /etc/redhat-release && echo "RedHat" && exit 0 || test -f /etc/debian_version && echo "Debian" && exit 0 || test -f /etc/SuSE-release && echo "Suse" && exit 0 || echo "Unknown")'

--- a/tasks/installimage.yml
+++ b/tasks/installimage.yml
@@ -48,12 +48,19 @@
   delegate_to: localhost
 
 # uses raw instead of module as python might not be installed yet
-- name: update apt repositories
-  raw: apt-get update
-
-# uses raw instead of module as python might not be installed yet
 - name: install python on remote host
   raw: apt-get install python -y
+  when: ansible_os_family == "Debian"
+
+# uses raw instead of module as python might not be installed yet
+- name: install python3 on remote host
+  raw: yum -y install python3
+  when: ansible_os_family == "RedHat"
+
+- name: update system
+  package:
+    name: "*"
+    state: latest
 
 - name: generate hostcode
   set_fact:

--- a/tasks/installimage.yml
+++ b/tasks/installimage.yml
@@ -47,19 +47,32 @@
     timeout: 180
   delegate_to: localhost
 
-# uses raw instead of module as python might not be installed yet
-- name: install python on remote host
-  raw: apt-get install python -y
-  when: ansible_os_family == "Debian"
+# uses raw instead of module as python might ont be installed yet
+- name: easy os detector
+  raw: 'echo -n $(test -f /etc/redhat-release && echo "RedHat" && exit 0 || test -f /etc/debian_version && echo "Debian" && exit 0 || test -f /etc/SuSE-release && echo "Suse" && exit 0 || echo "Unknown")'
+  register: os_switch
+  changed_when: false
 
-# uses raw instead of module as python might not be installed yet
-- name: install python3 on remote host
-  raw: yum -y install python3
-  when: ansible_os_family == "RedHat"
+# uses raw instead of module as python might ont be installed yet
+- name: (Debian/Ubuntu) install python
+  raw: 'apt-get install python -y'
+  when:
+    - os_switch is defined
+    - os_switch.stdout == 'Debian'
 
-- name: update system
+# uses raw instead of module as python might ont be installed yet
+- name: (RedHat) install python3
+  raw: 'yum -y install python3'
+  when:
+    - os_switch is defined
+    - os_switch.stdout == 'RedHat'
+
+- name: update facts
+  setup:
+
+- name: update packages
   package:
-    name: "*"
+    name: '*'
     state: latest
 
 - name: generate hostcode

--- a/tasks/rescuemode.yml
+++ b/tasks/rescuemode.yml
@@ -54,3 +54,5 @@
     delay: 1
     timeout: 180
   delegate_to: localhost
+
+- include: add_server_to_known_hosts.yml


### PR DESCRIPTION
When using the installer with a recent CentOS Image, it fails in
the last steps due to the apt-get calls. To also support Red Hat
based images at Hetzner, a small when + new task was added to
allow the role to support both image types.